### PR TITLE
Use project reference in sample apps

### DIFF
--- a/BooksAndPubs/BooksAndPubs.csproj
+++ b/BooksAndPubs/BooksAndPubs.csproj
@@ -29,9 +29,7 @@
   </Target>
 
   <ItemGroup>
-    <Reference Include="TuringTrader.Simulator">
-      <HintPath>C:\Program Files\TuringTrader\Bin\TuringTrader.Simulator.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\TuringTrader.Simulator\TuringTrader.Simulator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BooksAndPubsV2/BooksAndPubsV2.csproj
+++ b/BooksAndPubsV2/BooksAndPubsV2.csproj
@@ -29,9 +29,7 @@
   </Target>
 
   <ItemGroup>
-    <Reference Include="TuringTrader.Simulator">
-      <HintPath>C:\Program Files\TuringTrader\Bin\TuringTrader.Simulator.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\TuringTrader.Simulator\TuringTrader.Simulator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/More/TuringTrader.CustomApp/TuringTrader.CustomApp.csproj
+++ b/More/TuringTrader.CustomApp/TuringTrader.CustomApp.csproj
@@ -7,13 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\Algorithms\Demo Algorithms\Demo01_Indicators.cs" Link="Demo01_Indicators.cs" />
+    <Compile Include="..\..\Algorithms\Demo Algorithms (V2)\Demo01_Indicators.cs" Link="Demo01_Indicators.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="TuringTrader.Simulator">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files\TuringTrader\Bin\TuringTrader.Simulator.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\TuringTrader.Simulator\TuringTrader.Simulator.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Using project references rather than direct DLL references helps Visual Studio build in the correct order, and also doesn't require TuringTrader to be installed to build and run the project.

Also adjusted one of the source references to the V2 folder, since it was pointing to a now re-named folder.